### PR TITLE
Allow usage of 1.0.0-dev branch of zend-expressive-authentication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "psr/container": "^1.0",
         "psr/http-message": "^1.0.1",
         "zendframework/zend-authentication": "^2.5.0",
-        "zendframework/zend-expressive-authentication": "^0.2 || ^1.0"
+        "zendframework/zend-expressive-authentication": "^0.2 || ^1.0.0-dev || ^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.3",
@@ -42,7 +42,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.0.x-dev"
         },
         "zf": {
             "config-provider": "Zend\\Expressive\\Authentication\\ZendAuthentication\\ConfigProvider"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4da2d2233344b7d86570acd2a34fbf64",
+    "content-hash": "6eeeaf994e72f86064e57ddfd073a570",
     "packages": [
         {
             "name": "http-interop/http-middleware",
@@ -1896,7 +1896,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "zendframework/zend-expressive-authentication": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
The 1.0.0-dev branch of zend-expressive-authentication prepares for incorporation of PSR-15 interfaces; however, the API it exposes for adapters does not change.