### PR TITLE
ResponseFactory is passed to service instead of response prototype

### DIFF
--- a/src/ZendAuthentication.php
+++ b/src/ZendAuthentication.php
@@ -2,7 +2,7 @@
 /**
  * @see https://github.com/zendframework/zend-exprsesive-authentication-zendauthentication
  *     for the canonical source repository
- * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2017-2018 Zend Technologies USA Inc. (http://www.zend.com)
  * @license https://github.com/zendframework/zend-exprsesive-authentication-zendauthentication/blob/master/LICENSE.md
  *     New BSD License
  */
@@ -31,30 +31,24 @@ class ZendAuthentication implements AuthenticationInterface
     protected $config;
 
     /**
-     * @var ResponseInterface
+     * @var callable
      */
-    protected $responsePrototype;
+    protected $responseFactory;
 
-    /**
-     * Constructor
-     *
-     * @param AuthenticationService $auth
-     * @param array $config
-     * @param ResponseInterface $responsePrototype
-     */
     public function __construct(
         AuthenticationService $auth,
         array $config,
-        ResponseInterface $responsePrototype
+        callable $responseFactory
     ) {
         $this->auth = $auth;
         $this->config = $config;
-        $this->responsePrototype = $responsePrototype;
+
+        // Ensures type safety of the composed factory
+        $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
+            return $responseFactory();
+        };
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function authenticate(ServerRequestInterface $request) : ?UserInterface
     {
         if ('POST' === strtoupper($request->getMethod())) {
@@ -66,12 +60,9 @@ class ZendAuthentication implements AuthenticationInterface
             : null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function unauthorizedResponse(ServerRequestInterface $request): ResponseInterface
+    public function unauthorizedResponse(ServerRequestInterface $request) : ResponseInterface
     {
-        return $this->responsePrototype
+        return ($this->responseFactory)()
             ->withHeader(
                 'Location',
                 $this->config['redirect']

--- a/src/ZendAuthenticationFactory.php
+++ b/src/ZendAuthenticationFactory.php
@@ -10,14 +10,12 @@
 namespace Zend\Expressive\Authentication\ZendAuthentication;
 
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
 use Zend\Authentication\AuthenticationService;
 use Zend\Expressive\Authentication\Exception;
-use Zend\Expressive\Authentication\ResponsePrototypeTrait;
 
 class ZendAuthenticationFactory
 {
-    use ResponsePrototypeTrait;
-
     public function __invoke(ContainerInterface $container) : ZendAuthentication
     {
         $auth = $container->has(AuthenticationService::class)
@@ -42,7 +40,7 @@ class ZendAuthenticationFactory
         return new ZendAuthentication(
             $auth,
             $config,
-            $this->getResponsePrototype($container)
+            $container->get(ResponseInterface::class)
         );
     }
 }

--- a/test/ZendAuthenticationTest.php
+++ b/test/ZendAuthenticationTest.php
@@ -33,15 +33,17 @@ class ZendAuthenticationTest extends TestCase
     /** @var UserInterface|ObjectProphecy */
     private $authenticatedUser;
 
-    /** @var ResponseInterface|ObjectProphecy */
-    private $responsePrototype;
+    /** @var callable */
+    private $responseFactory;
 
     protected function setUp()
     {
         $this->request = $this->prophesize(ServerRequestInterface::class);
         $this->authService = $this->prophesize(AuthenticationService::class);
         $this->authenticatedUser = $this->prophesize(UserInterface::class);
-        $this->responsePrototype = $this->prophesize(ResponseInterface::class);
+        $this->responseFactory = function () {
+            return $this->prophesize(ResponseInterface::class)->reveal();
+        };
     }
 
     public function testConstructor()
@@ -49,7 +51,7 @@ class ZendAuthenticationTest extends TestCase
         $zendAuthentication = new ZendAuthentication(
             $this->authService->reveal(),
             [],
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
         $this->assertInstanceOf(AuthenticationInterface::class, $zendAuthentication);
     }
@@ -63,7 +65,7 @@ class ZendAuthenticationTest extends TestCase
         $zendAuthentication = new ZendAuthentication(
             $this->authService->reveal(),
             [],
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
         $result = $zendAuthentication->authenticate($this->request->reveal());
         $this->assertInstanceOf(UserInterface::class, $result);
@@ -77,7 +79,7 @@ class ZendAuthenticationTest extends TestCase
         $zendAuthentication = new ZendAuthentication(
             $this->authService->reveal(),
             [],
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
         $this->assertNull($zendAuthentication->authenticate($this->request->reveal()));
     }
@@ -90,7 +92,7 @@ class ZendAuthenticationTest extends TestCase
         $zendAuthentication = new ZendAuthentication(
             $this->authService->reveal(),
             [],
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
         $this->assertNull($zendAuthentication->authenticate($this->request->reveal()));
     }
@@ -119,7 +121,7 @@ class ZendAuthenticationTest extends TestCase
         $zendAuthentication = new ZendAuthentication(
             $this->authService->reveal(),
             [],
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
         $this->assertNull($zendAuthentication->authenticate($this->request->reveal()));
     }
@@ -149,7 +151,7 @@ class ZendAuthenticationTest extends TestCase
         $zendAuthentication = new ZendAuthentication(
             $this->authService->reveal(),
             [],
-            $this->responsePrototype->reveal()
+            $this->responseFactory
         );
         $result = $zendAuthentication->authenticate($this->request->reveal());
         $this->assertInstanceOf(UserInterface::class, $result);


### PR DESCRIPTION
Before the response prototype was passed to the service so the second
fetch of the service used the same response.
The brand new response should be created each time the service is used.

Ref:
- https://github.com/zendframework/zend-expressive-authentication-oauth2/issues/16#issuecomment-368691028
- https://github.com/zendframework/zend-expressive-authentication/pull/19