### PR TITLE
avoid initiateAuthentication call on any forms with POST method behind authentication

### DIFF
--- a/src/ZendAuthentication.php
+++ b/src/ZendAuthentication.php
@@ -53,13 +53,16 @@ class ZendAuthentication implements AuthenticationInterface
 
     public function authenticate(ServerRequestInterface $request) : ?UserInterface
     {
-        if ('POST' === strtoupper($request->getMethod())) {
-            return $this->initiateAuthentication($request);
+        if (! $this->auth->hasIdentity()) {
+            if ('POST' === strtoupper($request->getMethod())) {
+                return $this->initiateAuthentication($request);
+            }
+            $identity = null;
+        } else {
+            $identity = $this->generateUser($this->auth->getIdentity(), []);
         }
 
-        return $this->auth->hasIdentity()
-            ? $this->generateUser($this->auth->getIdentity(), [])
-            : null;
+        return $identity;
     }
 
     public function unauthorizedResponse(ServerRequestInterface $request) : ResponseInterface


### PR DESCRIPTION
If we are use AuthenticationMiddleware and ZendAuthentication together then ZendAuthentication tries to initiate authentication on every POST request in protected area. Such behavior prevents using any form behind authentication

This pull request adds an hasIdentity check before validating method and allows forms with POST behind authentication